### PR TITLE
Refactor viewer and utility functions; add maximize toggle feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ cppman.nvim adds a few mappings on top:
 * `K` on a table-of-contents entry: jump to that section
 * `<C-T>` or right-click: go back to the previous cppman page/search
 * `<Tab>`: go forward again after going back
+* `<M-m>`: toggle between the configured size and a maximized view
 * `q`: close the viewer
 
 Visual mode works too:

--- a/doc/cppman.txt
+++ b/doc/cppman.txt
@@ -140,6 +140,7 @@ cppman.nvim adds a few mappings on top:
 - `K` on a table-of-contents entry: jump to that section
 - `<C-T>` or right-click: go back to the previous cppman page/search
 - `<Tab>`: go forward again after going back
+- `<M-m>`: toggle between the configured size and a maximized view
 - `q`: close the viewer
 
 Visual mode works too:

--- a/lua/cppman/health.lua
+++ b/lua/cppman/health.lua
@@ -56,7 +56,12 @@ function M.check()
 	end
 
 	local fzf_status = statuses["fzf-lua"]
-	if fzf_status and fzf_status.available and vim.fn.executable("fzf") == 0 and not (picker_opts.fzf_lua or {}).fzf_bin then
+	if
+		fzf_status
+		and fzf_status.available
+		and vim.fn.executable("fzf") == 0
+		and not (picker_opts.fzf_lua or {}).fzf_bin
+	then
 		h.warn("fzf executable not found", { "Install fzf, or configure fzf-lua to use another fzf-compatible binary" })
 	end
 

--- a/lua/cppman/health.lua
+++ b/lua/cppman/health.lua
@@ -56,7 +56,7 @@ function M.check()
 	end
 
 	local fzf_status = statuses["fzf-lua"]
-	if fzf_status and fzf_status.available and vim.fn.executable("fzf") == 0 and not picker_opts.fzf_lua.fzf_bin then
+	if fzf_status and fzf_status.available and vim.fn.executable("fzf") == 0 and not (picker_opts.fzf_lua or {}).fzf_bin then
 		h.warn("fzf executable not found", { "Install fzf, or configure fzf-lua to use another fzf-compatible binary" })
 	end
 

--- a/lua/cppman/index.lua
+++ b/lua/cppman/index.lua
@@ -1,18 +1,11 @@
 local M = {}
 
-local uv = vim.uv or vim.loop
 local SOURCE_PRIORITY = { "cppreference.com", "cplusplus.com" }
 local VALID_SOURCES = { ["cppreference.com"] = true, ["cplusplus.com"] = true, ["both"] = true }
 
 local _cache = {}
 local _exact_map = {}
 local _db_path = nil
-
-M.last_load_ms = nil
-
-local function now_ms()
-	return uv.hrtime() / 1e6
-end
 
 local function validate_source(source)
 	if not VALID_SOURCES[source] then
@@ -412,11 +405,9 @@ function M.load(source)
 	source = get_source_mode(source)
 
 	if _cache[source] then
-		M.last_load_ms = nil
 		return _cache[source]
 	end
 
-	local t0 = now_ms()
 	if source == "both" then
 		local items = {}
 		local exact_map = {}
@@ -444,7 +435,6 @@ function M.load(source)
 		load_single_source(source)
 	end
 
-	M.last_load_ms = now_ms() - t0
 	return _cache[source] or {}
 end
 
@@ -469,7 +459,6 @@ function M.reset()
 	_cppman_paths = nil
 	_cppman_base_dir = nil
 	_cppman_base_dir_resolved = false
-	M.last_load_ms = nil
 end
 
 return M

--- a/lua/cppman/index.lua
+++ b/lua/cppman/index.lua
@@ -229,7 +229,8 @@ local function cppman_base_dir()
 		return vim.system(
 			{ "python3", "-c", "import cppman, os; print(os.path.dirname(cppman.__file__))" },
 			{ text = true }
-		):wait()
+		)
+			:wait()
 	end)
 	if ok and res.code == 0 then
 		local base = vim.trim(res.stdout or "")

--- a/lua/cppman/index.lua
+++ b/lua/cppman/index.lua
@@ -190,7 +190,12 @@ local function run_sqlite(db_path, query, separator)
 	end
 	args[#args + 1] = db_path
 	args[#args + 1] = query
-	local res = vim.system(args, { text = true }):wait()
+	local ok, res = pcall(function()
+		return vim.system(args, { text = true }):wait()
+	end)
+	if not ok then
+		return nil, "failed to run sqlite3: " .. tostring(res)
+	end
 	if res.code ~= 0 then
 		return nil, (res.stderr ~= "" and res.stderr) or "sqlite3 exited " .. res.code
 	end
@@ -220,12 +225,13 @@ local function cppman_base_dir()
 		return _cppman_base_dir
 	end
 	_cppman_base_dir_resolved = true
-	local res = vim.system(
-		{ "python3", "-c", "import cppman, os; print(os.path.dirname(cppman.__file__))" },
-		{ text = true }
-	)
-		:wait()
-	if res.code == 0 then
+	local ok, res = pcall(function()
+		return vim.system(
+			{ "python3", "-c", "import cppman, os; print(os.path.dirname(cppman.__file__))" },
+			{ text = true }
+		):wait()
+	end)
+	if ok and res.code == 0 then
 		local base = vim.trim(res.stdout or "")
 		if base ~= "" then
 			_cppman_base_dir = base

--- a/lua/cppman/picker.lua
+++ b/lua/cppman/picker.lua
@@ -14,8 +14,6 @@ local PROVIDERS = {
 	},
 }
 
-M.last_pattern = ""
-
 local function now_ms()
 	return uv.hrtime() / 1e6
 end
@@ -151,9 +149,6 @@ function M.open(opts)
 		source = source,
 		items = items,
 		load_ms = load_ms,
-		set_last_pattern = function(pattern)
-			M.last_pattern = pattern or ""
-		end,
 	}))
 end
 

--- a/lua/cppman/picker.lua
+++ b/lua/cppman/picker.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local uv = vim.uv or vim.loop
+local util = require("cppman.util")
 
 local AUTO_ORDER = { "snacks", "fzf-lua" }
 local PROVIDERS = {
@@ -13,10 +13,6 @@ local PROVIDERS = {
 		module = "cppman.pickers.fzf_lua",
 	},
 }
-
-local function now_ms()
-	return uv.hrtime() / 1e6
-end
 
 local function picker_options()
 	local config = require("cppman.config")
@@ -135,9 +131,9 @@ function M.open(opts)
 	local source = opts.source or config.options.source or "both"
 
 	local index = require("cppman.index")
-	local t0 = now_ms()
+	local t0 = util.now_ms()
 	local items = index.load(source)
-	local load_ms = now_ms() - t0
+	local load_ms = util.now_ms() - t0
 	if #items == 0 then
 		vim.notify("[cppman] no items loaded - check cppman and sqlite3 installation", vim.log.levels.ERROR)
 		return

--- a/lua/cppman/pickers/common.lua
+++ b/lua/cppman/pickers/common.lua
@@ -1,13 +1,8 @@
 local M = {}
 
-local NBSP = vim.fn.nr2char(160)
+local util = require("cppman.util")
 
-function M.format_timing(elapsed)
-	if elapsed < 10 then
-		return string.format("%.1fms", elapsed)
-	end
-	return string.format("%dms", math.floor(elapsed + 0.5))
-end
+local NBSP = vim.fn.nr2char(160)
 
 function M.source_badge(source)
 	if source == "cppreference.com" then
@@ -29,7 +24,7 @@ end
 function M.search_title(load_ms)
 	return {
 		{ "keyword", "Title" },
-		{ NBSP .. "search • " .. M.format_timing(load_ms), "Comment" },
+		{ NBSP .. "search • " .. util.format_ms(load_ms), "Comment" },
 		{ " ", "FloatTitle" },
 	}
 end

--- a/lua/cppman/pickers/fzf_lua.lua
+++ b/lua/cppman/pickers/fzf_lua.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local common = require("cppman.pickers.common")
+local util = require("cppman.util")
 
 function M.is_available()
 	local ok, FzfLua = pcall(require, "fzf-lua")
@@ -96,7 +97,7 @@ function M.open(opts)
 		winopts = {
 			backdrop = 100,
 			border = "rounded",
-			title = " keyword search - " .. common.format_timing(opts.load_ms or 0) .. " ",
+			title = " keyword search - " .. util.format_ms(opts.load_ms or 0) .. " ",
 			title_pos = "center",
 			width = picker_opts.width or 0.4,
 			height = picker_opts.height or 0.4,

--- a/lua/cppman/pickers/fzf_lua.lua
+++ b/lua/cppman/pickers/fzf_lua.lua
@@ -68,9 +68,6 @@ function M.open(opts)
 			end
 
 			local used_pattern = last_query(FzfLua, pattern)
-			if opts.set_last_pattern then
-				opts.set_last_pattern(used_pattern)
-			end
 			if on_select then
 				on_select(item, used_pattern)
 			end

--- a/lua/cppman/pickers/snacks.lua
+++ b/lua/cppman/pickers/snacks.lua
@@ -69,9 +69,6 @@ function M.open(opts)
 					return picker.input.filter.pattern
 				end)
 				local used_pattern = (ok_pattern and current) or pattern
-				if opts.set_last_pattern then
-					opts.set_last_pattern(used_pattern)
-				end
 				picker:close()
 				if on_select then
 					on_select(item, used_pattern)

--- a/lua/cppman/render.lua
+++ b/lua/cppman/render.lua
@@ -195,7 +195,6 @@ function M.render_page(page, query, width, source)
 	end
 
 	local t0 = now_ms()
-	local external_t0 = now_ms()
 
 	local stdout = nil
 	local page_path = get_cached_page_path(page, source)
@@ -208,7 +207,7 @@ function M.render_page(page, query, width, source)
 		if res.code ~= 0 or not res.stdout or res.stdout == "" then
 			lru_set(page_cache, key, false)
 			return nil, {
-				cppman_ms = now_ms() - external_t0,
+				cppman_ms = now_ms() - t0,
 				our_ms = 0,
 				total_ms = now_ms() - t0,
 			}
@@ -216,7 +215,7 @@ function M.render_page(page, query, width, source)
 		stdout = res.stdout
 	end
 
-	local cppman_ms = now_ms() - external_t0
+	local cppman_ms = now_ms() - t0
 	local internal_t0 = now_ms()
 
 	local lines = vim.split(stdout, "\n", { plain = true })

--- a/lua/cppman/render.lua
+++ b/lua/cppman/render.lua
@@ -4,7 +4,7 @@
 -- never re-spawn cppman. Owns no window state — viewer.lua handles UI.
 local M = {}
 
-local uv = vim.uv or vim.loop
+local util = require("cppman.util")
 local index = require("cppman.index")
 
 local plugin_cache_dir = vim.fn.stdpath("cache") .. "/cppman_plugin"
@@ -40,10 +40,6 @@ page_cache.max = PAGE_CACHE_MAX
 local resolve_cache = new_lru()
 resolve_cache.max = RESOLVE_CACHE_MAX
 local _pager_script = nil
-
-local function now_ms()
-	return uv.hrtime() / 1e6
-end
 
 local function get_source(source)
 	return index.get_sources(source)[1]
@@ -202,7 +198,7 @@ function M.render_page(page, query, width, source)
 		return cached or nil, nil
 	end
 
-	local t0 = now_ms()
+	local t0 = util.now_ms()
 
 	local stdout = nil
 	local page_path = get_cached_page_path(page, source)
@@ -215,16 +211,16 @@ function M.render_page(page, query, width, source)
 		if res.code ~= 0 or not res.stdout or res.stdout == "" then
 			lru_set(page_cache, key, false)
 			return nil, {
-				cppman_ms = now_ms() - t0,
+				cppman_ms = util.now_ms() - t0,
 				our_ms = 0,
-				total_ms = now_ms() - t0,
+				total_ms = util.now_ms() - t0,
 			}
 		end
 		stdout = res.stdout
 	end
 
-	local cppman_ms = now_ms() - t0
-	local internal_t0 = now_ms()
+	local cppman_ms = util.now_ms() - t0
+	local internal_t0 = util.now_ms()
 
 	local lines = vim.split(stdout, "\n", { plain = true })
 	if lines[#lines] == "" then
@@ -237,17 +233,17 @@ function M.render_page(page, query, width, source)
 		lru_set(page_cache, key, false)
 		return nil, {
 			cppman_ms = cppman_ms,
-			our_ms = now_ms() - internal_t0,
-			total_ms = now_ms() - t0,
+			our_ms = util.now_ms() - internal_t0,
+			total_ms = util.now_ms() - t0,
 		}
 	end
 
-	local our_ms = now_ms() - internal_t0
+	local our_ms = util.now_ms() - internal_t0
 	lru_set(page_cache, key, lines)
 	return lines, {
 		cppman_ms = cppman_ms,
 		our_ms = our_ms,
-		total_ms = now_ms() - t0,
+		total_ms = util.now_ms() - t0,
 	}
 end
 

--- a/lua/cppman/render.lua
+++ b/lua/cppman/render.lua
@@ -231,11 +231,12 @@ function M.render_page(page, query, width, source)
 
 	if #lines == 0 then
 		lru_set(page_cache, key, false)
-		return nil, {
-			cppman_ms = cppman_ms,
-			our_ms = util.now_ms() - internal_t0,
-			total_ms = util.now_ms() - t0,
-		}
+		return nil,
+			{
+				cppman_ms = cppman_ms,
+				our_ms = util.now_ms() - internal_t0,
+				total_ms = util.now_ms() - t0,
+			}
 	end
 
 	local our_ms = util.now_ms() - internal_t0

--- a/lua/cppman/render.lua
+++ b/lua/cppman/render.lua
@@ -84,14 +84,20 @@ local function cppman_args(extra)
 end
 
 local function run_cppman(source, args, stdin)
-	return vim.system(args, {
-		env = {
-			XDG_CACHE_HOME = plugin_cache_dir,
-			XDG_CONFIG_HOME = get_config_dir(get_source(source)),
-		},
-		stdin = stdin,
-		text = true,
-	}):wait()
+	local ok, res = pcall(function()
+		return vim.system(args, {
+			env = {
+				XDG_CACHE_HOME = plugin_cache_dir,
+				XDG_CONFIG_HOME = get_config_dir(get_source(source)),
+			},
+			stdin = stdin,
+			text = true,
+		}):wait()
+	end)
+	if not ok then
+		return { code = -1, stdout = "", stderr = tostring(res) }
+	end
+	return res
 end
 
 local function normalize_page_name(name)
@@ -141,8 +147,10 @@ local function render_cached_page(page_path, width, page)
 	if not pager_script then
 		return nil
 	end
-	local res = vim.system({ pager_script, "pipe", page_path, tostring(width), "", page }, { text = true }):wait()
-	if res.code ~= 0 or not res.stdout or res.stdout == "" then
+	local ok, res = pcall(function()
+		return vim.system({ pager_script, "pipe", page_path, tostring(width), "", page }, { text = true }):wait()
+	end)
+	if not ok or res.code ~= 0 or not res.stdout or res.stdout == "" then
 		return nil
 	end
 	return res.stdout

--- a/lua/cppman/util.lua
+++ b/lua/cppman/util.lua
@@ -1,0 +1,22 @@
+-- Small shared helpers with no plugin state.
+local M = {}
+
+local uv = vim.uv or vim.loop
+
+function M.now_ms()
+	return uv.hrtime() / 1e6
+end
+
+-- Format an elapsed-milliseconds value for display.
+-- nil means "no measurement" (e.g. an in-memory cache hit).
+function M.format_ms(elapsed)
+	if elapsed == nil then
+		return "cached"
+	end
+	if elapsed < 10 then
+		return string.format("%.1fms", elapsed)
+	end
+	return string.format("%dms", math.floor(elapsed + 0.5))
+end
+
+return M

--- a/lua/cppman/viewer.lua
+++ b/lua/cppman/viewer.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local uv = vim.uv or vim.loop
+local util = require("cppman.util")
 
 local _config, _history, _index, _render
 local function config()
@@ -32,10 +32,6 @@ local _current_sections = nil
 local go_back
 local go_forward
 local open_picker_for_back
-
-local function now_ms()
-	return uv.hrtime() / 1e6
-end
 
 local function is_valid()
 	return state.win and vim.api.nvim_win_is_valid(state.win) and state.buf and vim.api.nvim_buf_is_valid(state.buf)
@@ -227,25 +223,15 @@ local function jump_to_toc_section()
 	return true
 end
 
-local function format_timing_value(elapsed)
-	if elapsed == nil then
-		return "cached"
-	end
-	if elapsed < 10 then
-		return string.format("%.1fms", elapsed)
-	end
-	return string.format("%dms", math.floor(elapsed + 0.5))
-end
-
 local function format_timing_breakdown(timing)
 	if timing == nil then
 		return "cached"
 	end
 	return string.format(
 		"cppman: %s | our: %s | total: %s",
-		format_timing_value(timing.cppman_ms),
-		format_timing_value(timing.our_ms),
-		format_timing_value(timing.total_ms)
+		util.format_ms(timing.cppman_ms),
+		util.format_ms(timing.our_ms),
+		util.format_ms(timing.total_ms)
 	)
 end
 
@@ -267,7 +253,7 @@ local function load_page(item, lines, timing, cursor)
 		end
 	end
 
-	local ui_t0 = now_ms()
+	local ui_t0 = util.now_ms()
 	local buf = state.buf
 	vim.bo[buf].ro = false
 	vim.bo[buf].ma = true
@@ -292,7 +278,7 @@ local function load_page(item, lines, timing, cursor)
 	_current_page_label = extract_page_label(item.page, lines)
 	_current_sections = sections_mod.build(lines)
 	if timing then
-		local ui_ms = now_ms() - ui_t0
+		local ui_ms = util.now_ms() - ui_t0
 		timing.our_ms = timing.our_ms + ui_ms
 		timing.total_ms = timing.total_ms + ui_ms
 	end

--- a/lua/cppman/viewer.lua
+++ b/lua/cppman/viewer.lua
@@ -456,17 +456,7 @@ local function follow_word(word, fallback_word)
 		history().push(snap)
 		history().forward_clear()
 	end
-	require("cppman.picker").open({
-		search = word,
-		source = source,
-		on_back = go_back,
-		on_select = function(item, used_pattern)
-			history().push({ type = "search", pattern = used_pattern, source = source })
-			history().forward_clear()
-			load_page(item)
-			refocus_viewer()
-		end,
-	})
+	open_picker_for_back(word, source)
 end
 
 local function get_visual_selection()

--- a/lua/cppman/viewer.lua
+++ b/lua/cppman/viewer.lua
@@ -20,7 +20,7 @@ local function render()
 	return _render
 end
 
-local state = { win = nil, buf = nil }
+local state = { win = nil, buf = nil, maximized = false }
 local _current_page_name = nil
 local _current_page_query = nil
 local _current_page_source = nil
@@ -35,6 +35,23 @@ local open_picker_for_back
 
 local function is_valid()
 	return state.win and vim.api.nvim_win_is_valid(state.win) and state.buf and vim.api.nvim_buf_is_valid(state.buf)
+end
+
+-- The double border occupies one cell on each side; keep the bordered float
+-- inside the editor so a full-size window never overflows.
+local BORDER_PADDING = 2
+
+-- Float geometry as (width, height, row, col). When `maximized`, fills the
+-- editor; otherwise uses the configured viewer width/height ratios.
+local function compute_geometry(maximized)
+	local ui = vim.api.nvim_list_uis()[1]
+	local w = maximized and 1.0 or (config().options.viewer.width or 0.8)
+	local h = maximized and 1.0 or (config().options.viewer.height or 0.6)
+	local win_w = math.min(math.floor(ui.width * w), ui.width - BORDER_PADDING)
+	local win_h = math.min(math.floor(ui.height * h), ui.height - BORDER_PADDING)
+	local row = math.floor((ui.height - win_h) / 2)
+	local col = math.floor((ui.width - win_w) / 2)
+	return win_w, win_h, row, col
 end
 
 -- Snapshot of the current page suitable for pushing onto a history stack.
@@ -497,6 +514,45 @@ local function close()
 	end
 end
 
+-- Toggle the viewer between its configured size and a full-editor view.
+-- No-op when the configured view already fills the screen.
+local function toggle_maximize()
+	if not is_valid() then
+		return
+	end
+
+	local norm_w, norm_h = compute_geometry(false)
+	local max_w, max_h = compute_geometry(true)
+	if norm_w >= max_w and norm_h >= max_h then
+		return
+	end
+
+	state.maximized = not state.maximized
+	local win_w, win_h, row, col = compute_geometry(state.maximized)
+
+	local ok, cfg = pcall(vim.api.nvim_win_get_config, state.win)
+	if not ok then
+		return
+	end
+	cfg.width = win_w
+	cfg.height = win_h
+	cfg.row = row
+	cfg.col = col
+	pcall(vim.api.nvim_win_set_config, state.win, cfg)
+
+	-- Re-render so the page re-wraps to the new width (also refreshes the footer).
+	if _current_page_name then
+		local cur_ok, cursor = pcall(vim.api.nvim_win_get_cursor, state.win)
+		load_page({
+			page = _current_page_name,
+			query = _current_page_query,
+			source = _current_page_source,
+		}, nil, nil, cur_ok and cursor or nil)
+	else
+		set_footer(_current_page_label, _current_timing_text)
+	end
+end
+
 local function setup_keymaps(buf)
 	local function map(mode, lhs, rhs)
 		vim.keymap.set(mode, lhs, rhs, { silent = true, buffer = buf })
@@ -535,6 +591,7 @@ local function setup_keymaps(buf)
 	map("n", "<C-T>", go_back)
 	map("n", "<RightMouse>", go_back)
 	map("n", "<Tab>", go_forward)
+	map("n", "<M-m>", toggle_maximize)
 end
 
 function M.reset()
@@ -583,14 +640,8 @@ function M.open(opts)
 	local buf = vim.api.nvim_create_buf(false, true)
 	vim.bo[buf].bufhidden = "wipe"
 
-	local ui = vim.api.nvim_list_uis()[1]
-
-	local w = config().options.viewer.width or 0.8
-	local h = config().options.viewer.height or 0.6
-	local win_w = math.floor(ui.width * w)
-	local win_h = math.floor(ui.height * h)
-	local row = math.floor((ui.height - win_h) / 2)
-	local col = math.floor((ui.width - win_w) / 2)
+	state.maximized = false
+	local win_w, win_h, row, col = compute_geometry(false)
 
 	local win = vim.api.nvim_open_win(buf, true, {
 		relative = "editor",
@@ -628,6 +679,7 @@ function M.open(opts)
 			_current_sections = nil
 			state.win = nil
 			state.buf = nil
+			state.maximized = false
 		end,
 	})
 

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,1 @@
+sadpokapp


### PR DESCRIPTION
This pull request introduces a new maximize toggle feature for the viewer and refactors timing utilities throughout the codebase for improved consistency and error handling. The most significant changes are the addition of a maximize/minimize viewer mode, the centralization of timing and formatting helpers, and improved robustness in system command execution.

**Viewer maximize toggle and UI improvements:**

* Added a new mapping `<M-m>` (Alt+m) to toggle the viewer between its configured size and a maximized view, updating documentation in both `README.md` and `doc/cppman.txt`. (.claude/worktrees/feat+viewer-maximize-toggle, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126) [[2]](diffhunk://#diff-5bbe10d21abc9167e94fcc1f30a302f9c5424007179e1f9468bface803c2b3e9R143)
* Implemented maximize logic in `viewer.lua`, including geometry calculation to ensure the viewer fits within the editor without overflowing. [[1]](diffhunk://#diff-418dbdd9cddceb899e86cedca449e9754afe27f5ed27efb8609b93630c0329a1L23-R23) [[2]](diffhunk://#diff-418dbdd9cddceb899e86cedca449e9754afe27f5ed27efb8609b93630c0329a1L36-R56)

**Timing and utility refactoring:**

* Extracted timing and formatting helpers into a new module `util.lua` (`now_ms`, `format_ms`), replacing duplicated code in multiple files and ensuring consistent elapsed time reporting. [[1]](diffhunk://#diff-8e520cf2e63f85ad21044ca649d6fc4b5096de6d6ac6a2778b83de4ed616e81fR1-R22) [[2]](diffhunk://#diff-2ad5ce0049da73b99869fc3482c46fd0c8c0e9915db16197b56ac3df054ca772L3-R3) [[3]](diffhunk://#diff-2ad5ce0049da73b99869fc3482c46fd0c8c0e9915db16197b56ac3df054ca772L17-L22) [[4]](diffhunk://#diff-3ebfc60d65c87b0872a4a6f462bfd4948717a62e1f79f40bf6860505405f3d74L7-R7) [[5]](diffhunk://#diff-45f5c1ae50a258a861946efa47629c5f30da6ecd7d8c18c185e3dac73cfcf6beL3-R5) [[6]](diffhunk://#diff-45f5c1ae50a258a861946efa47629c5f30da6ecd7d8c18c185e3dac73cfcf6beL32-R27) [[7]](diffhunk://#diff-15c2790b05a3de1de57a8abcb168078dd9e30fb9df576d5d0fe73558a95c4880R4) [[8]](diffhunk://#diff-15c2790b05a3de1de57a8abcb168078dd9e30fb9df576d5d0fe73558a95c4880L102-R100) [[9]](diffhunk://#diff-418dbdd9cddceb899e86cedca449e9754afe27f5ed27efb8609b93630c0329a1L230-R251) [[10]](diffhunk://#diff-418dbdd9cddceb899e86cedca449e9754afe27f5ed27efb8609b93630c0329a1L270-R273) [[11]](diffhunk://#diff-418dbdd9cddceb899e86cedca449e9754afe27f5ed27efb8609b93630c0329a1L295-R298) [[12]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L3-L16) [[13]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L415-L419) [[14]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L447) [[15]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L472)

**System command error handling:**

* Wrapped all `vim.system` calls in `pcall` to gracefully handle errors and prevent crashes when external commands fail, improving robustness in `index.lua`, `render.lua`, and related modules. [[1]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L200-R198) [[2]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L230-R234) [[3]](diffhunk://#diff-3ebfc60d65c87b0872a4a6f462bfd4948717a62e1f79f40bf6860505405f3d74R83) [[4]](diffhunk://#diff-3ebfc60d65c87b0872a4a6f462bfd4948717a62e1f79f40bf6860505405f3d74R92-R96) [[5]](diffhunk://#diff-3ebfc60d65c87b0872a4a6f462bfd4948717a62e1f79f40bf6860505405f3d74L144-R149)

**Minor improvements and bug fixes:**

* Fixed a bug in the health check logic to correctly handle missing `fzf` binaries when `fzf-lua` is configured.
* Removed unused fields and functions related to timing and pattern tracking in several modules for code simplification. [[1]](diffhunk://#diff-2ad5ce0049da73b99869fc3482c46fd0c8c0e9915db16197b56ac3df054ca772L17-L22) [[2]](diffhunk://#diff-2ad5ce0049da73b99869fc3482c46fd0c8c0e9915db16197b56ac3df054ca772L154-L156) [[3]](diffhunk://#diff-15c2790b05a3de1de57a8abcb168078dd9e30fb9df576d5d0fe73558a95c4880L71-L73) [[4]](diffhunk://#diff-511332fa196b43460fcab5a5a376db78506c2a56d2dd6790770ce9fb07984470L72-L74) [[5]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L3-L16) [[6]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L415-L419) [[7]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L447) [[8]](diffhunk://#diff-3ed1eae8cd163f7627c5f12ed7d7f4e233a45eb1ec6d4fad899164f49880af98L472)