### PR TITLE
Update smoke.yml to use wretry for Neovim setup

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,10 +20,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Neovim
-        uses: rhysd/action-setup-vim@v1
+        uses: Wandalen/wretry.action@v3
         with:
-          neovim: true
-          version: ${{ matrix.neovim }}
+          action: rhysd/action-setup-vim@v1
+          with: |
+            neovim: true
+            version: ${{ matrix.neovim }}
+          attempt_limit: 3
+          attempt_delay: 15000
 
       - name: Install picker dependency
         run: |


### PR DESCRIPTION
This pull request updates the Neovim setup step in the smoke test GitHub Actions workflow to make it more robust by adding retry logic. Instead of directly using the Neovim setup action, it now wraps it with a retry mechanism to handle transient failures.

**CI/CD workflow reliability improvements:**

* The `Setup Neovim` step in `.github/workflows/smoke.yml` now uses `Wandalen/wretry.action@v3` to wrap `rhysd/action-setup-vim@v1`, adding retry logic with up to 3 attempts and a 15-second delay between retries.